### PR TITLE
Disable safe directory warnings

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,7 @@ DEFAULT_GITHUB_REF=${GITHUB_REF:11}
 
 mirror_repo="$MIRROR_REPO"
 
+sh -c "git config --global --add safe.directory '*'"
 sh -c "git config --global user.name $GITLAB_USERNAME"
 sh -c "git config --global user.email ${GITLAB_USERNAME}@${GITLAB_HOSTNAME}"
 sh -c "git config --global credential.username $GITLAB_USERNAME"


### PR DESCRIPTION
Recently, all our CI tests, in particular for cms-L1TK/cmssw and cms-L1TK/firmware-hls, have been failing with the following message:
```
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```
For example, see [this job](https://github.com/cms-L1TK/firmware-hls/actions/runs/6197841017/job/16827169908) in the firmware-hls repo.

This PR disables these errors, allowing the CI tests to proceed. For example, see [this job](https://github.com/cms-L1TK/firmware-hls/actions/runs/6198021750/job/16827683743) in the firmware-hls repo.